### PR TITLE
added remaining changes for svenson and JSON-lib JSON databind

### DIFF
--- a/tpc/src/data/media/Image.java
+++ b/tpc/src/data/media/Image.java
@@ -69,4 +69,44 @@ public class Image implements java.io.Serializable
 		sb.append("]");
 		return sb.toString();
 	}
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public void setSize(Size size) {
+        this.size = size;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public Size getSize() {
+        return size;
+    }
 }

--- a/tpc/src/data/media/Media.java
+++ b/tpc/src/data/media/Media.java
@@ -106,4 +106,93 @@ public class Media implements java.io.Serializable {
 		sb.append("]");
 		return sb.toString();
 	}
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public void setBitrate(int bitrate) {
+        this.bitrate = bitrate;
+        this.hasBitrate = true;
+    }
+
+    public void setPersons(List<String> persons) {
+        this.persons = persons;
+    }
+
+    public void setPlayer(Player player) {
+        this.player = player;
+    }
+
+    public void setCopyright(String copyright) {
+        this.copyright = copyright;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public int getBitrate() {
+        return bitrate;
+    }
+
+    public List<String> getPersons() {
+        return persons;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public String getCopyright() {
+        return copyright;
+    }
 }

--- a/tpc/src/data/media/MediaContent.java
+++ b/tpc/src/data/media/MediaContent.java
@@ -45,4 +45,20 @@ public class MediaContent implements java.io.Serializable
 		sb.append("]");
 		return sb.toString();
 	}
+
+    public void setMedia(Media media) {
+        this.media = media;
+    }
+
+    public void setImages(List<Image> images) {
+        this.images = images;
+    }
+
+    public Media getMedia() {
+        return media;
+    }
+
+    public List<Image> getImages() {
+        return images;
+    }
 }

--- a/tpc/src/serializers/JsonLibJsonDatabind.java
+++ b/tpc/src/serializers/JsonLibJsonDatabind.java
@@ -1,6 +1,8 @@
 package serializers;
 
 import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import data.media.Image;
 import data.media.Media;
@@ -21,16 +23,34 @@ public class JsonLibJsonDatabind
   {
     private final String name;
     private final Class<T> type;
+    // private final net.sf.ezmorph.MorpherRegistry _morpherRegistry;
+    private final net.sf.json.JsonConfig _jsonConfig;
 
     public GenericSerializer(String name, Class<T> clazz)
     {
       this.name = name;
       type = clazz;
 
-      net.sf.json.util.JSONUtils.getMorpherRegistry().registerMorpher(
-          new net.sf.json.util.EnumMorpher(Media.Player.class));
-      net.sf.json.util.JSONUtils.getMorpherRegistry().registerMorpher(
-          new net.sf.json.util.EnumMorpher(Image.Size.class));
+      net.sf.ezmorph.MorpherRegistry _morpherRegistry = net.sf.json.util.JSONUtils.getMorpherRegistry();
+      _morpherRegistry.registerMorpher(new net.sf.json.util.EnumMorpher(Media.Player.class));
+      _morpherRegistry.registerMorpher(new net.sf.json.util.EnumMorpher(Image.Size.class));
+      // "preferred" approach with BeanMorpher causes excessive info logging
+      // net.sf.ezmorph.Morpher imageMorpher = new net.sf.ezmorph.bean.BeanMorpher(Image.class, _morpherRegistry);
+      // _morpherRegistry.registerMorpher(imageMorpher);
+
+      _jsonConfig = new net.sf.json.JsonConfig();
+      _jsonConfig.setRootClass(type);
+
+      // else JSON null is turned into empty string, which fails equality tests
+      _jsonConfig.registerDefaultValueProcessor(String.class, 
+          new net.sf.json.processors.DefaultValueProcessor() 
+          {
+            @Override
+            public Object getDefaultValue(Class type)
+            {
+                return net.sf.json.JSONNull.getInstance();
+            }
+          });
     }
 
     public String getName()
@@ -38,12 +58,41 @@ public class JsonLibJsonDatabind
       return name;
     }
 
+    @SuppressWarnings("unchecked")
     public T deserialize(byte[] array) throws Exception
     {
       String jsonInput = new String(array, "UTF-8");
       net.sf.json.JSONObject jsonObject = net.sf.json.JSONObject.fromObject(jsonInput);
-      @SuppressWarnings("unchecked")
-      T result = (T) net.sf.json.JSONObject.toBean(jsonObject, type);
+      T result = (T) net.sf.json.JSONObject.toBean(jsonObject, _jsonConfig);
+
+      // JSON-lib cannot deserialize into a list of a custom type, when the list is a member of something.
+      // Instead, JSON-lib populates the list with MorphDynaBeans, which can be transformed to the target type.
+      MediaContent mediaContent = (MediaContent) result;
+      int size = mediaContent.images.size();
+      List<Image> replacementImages = new ArrayList<Image> (size);
+      for (int i = 0; i < size; i++)
+      {
+        // "preferred" approach with BeanMorpher causes excessive info logging -- TODO: figure out how to config
+        // Object image = mediaContent.images.get(i);
+        // replacementImages.add((Image)_morpherRegistry.morph(Image.class, image));
+
+        // alternate approach, still using JSON-lib components to transform data
+        Object o = mediaContent.images.get(i);
+        net.sf.ezmorph.bean.MorphDynaBean image = (net.sf.ezmorph.bean.MorphDynaBean) o;
+        net.sf.json.JSONObject imageJsonObject = net.sf.json.JSONObject.fromObject(image);
+        Image replacementImage = (Image) net.sf.json.JSONObject.toBean(imageJsonObject, Image.class);
+
+        // a slightly "manual" approach (?) that is about 10% faster, but isn't it cheating?
+        //Image replacementImage = new Image();
+        //replacementImage.height = (Integer) image.get("height");
+        //replacementImage.size = Image.Size.valueOf((String) image.get("size"));
+        //replacementImage.title = (String) image.get("title");
+        //replacementImage.uri = (String) image.get("uri");
+        //replacementImage.width = (Integer) image.get("width");
+
+        replacementImages.add(replacementImage);
+      }
+      mediaContent.images = replacementImages;
       return result;
     }
 
@@ -51,8 +100,7 @@ public class JsonLibJsonDatabind
     {
       ByteArrayOutputStream baos = outputStream(data);
       OutputStreamWriter w = new OutputStreamWriter(baos, "UTF-8");
-      net.sf.json.JSONObject jsonObject = net.sf.json.JSONObject.fromObject(data);
-      jsonObject.write(w);
+      net.sf.json.JSONSerializer.toJSON(data, _jsonConfig).write(w);
       w.close();
       return baos.toByteArray();
     }


### PR DESCRIPTION
With this change set, the svenson and JSON-lib JSON databind implementations are fully functional (with data sets media.1.cks, media.3.cks and media.4.cks -- many of the serializers fail round trip check with media.2.cks).
