### PR TITLE
buffers

### DIFF
--- a/tpc/src/serializers/Serializer.java
+++ b/tpc/src/serializers/Serializer.java
@@ -8,12 +8,15 @@ public abstract class Serializer<S>
 	public abstract byte[] serialize(S content) throws Exception;
  	public abstract String getName();
 
+	/* 15-May-2010, tsaloranta: For now, let's use a reasonable
+	 *  guess; not too small nor too large a buffer.
+	 */
+ 	private final ByteArrayOutputStream buffer = new ByteArrayOutputStream(500);
+
  	public ByteArrayOutputStream outputStream(S content)
  	{
- 	    /* 15-May-2010, tsaloranta: For now, let's use a reasonable
- 	     *  guess; not too small nor too large a buffer.
- 	     */
- 	    return new ByteArrayOutputStream(500);
+ 		buffer.reset();
+ 		return buffer;
  	}
 
  	// Multi-item interfaces

--- a/tpc/src/serializers/wobly/compact/WoblyCompactUtils.java
+++ b/tpc/src/serializers/wobly/compact/WoblyCompactUtils.java
@@ -1,6 +1,8 @@
 package serializers.wobly.compact;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -58,6 +60,8 @@ public class WoblyCompactUtils {
 	}
 	public static final class WoblySerializer extends Serializer<WMediaContent>
 	{
+		private static final ByteBuffer buffer = ByteBuffer.allocate(2048);
+
 		@Override
 		public WMediaContent deserialize(byte[] array)
 				throws Exception {
@@ -67,7 +71,9 @@ public class WoblyCompactUtils {
 		@Override
 		public byte[] serialize(WMediaContent content)
 				throws Exception {
-			return content.toByteArray();
+			buffer.clear();
+			content.write(buffer);
+			return Arrays.copyOf(buffer.array(), buffer.position());
 		}
 
 		@Override
@@ -75,5 +81,4 @@ public class WoblyCompactUtils {
 			return "wobly-compact";
 		}
 	}
-
 }

--- a/tpc/src/serializers/wobly/simple/WoblySimpleUtils.java
+++ b/tpc/src/serializers/wobly/simple/WoblySimpleUtils.java
@@ -1,6 +1,8 @@
 package serializers.wobly.simple;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,6 +59,8 @@ public class WoblySimpleUtils {
 	}
 	public static final class WoblySerializer extends Serializer<WMediaContent>
 	{
+		private static final ByteBuffer buffer = ByteBuffer.allocate(2048);
+
 		@Override
 		public WMediaContent deserialize(byte[] array)
 				throws Exception {
@@ -66,7 +70,9 @@ public class WoblySimpleUtils {
 		@Override
 		public byte[] serialize(WMediaContent content)
 				throws Exception {
-			return content.toByteArray();
+			buffer.clear();
+			content.write(buffer);
+			return Arrays.copyOf(buffer.array(), buffer.position());
 		}
 
 		@Override


### PR DESCRIPTION
Some serializers initialize buffer they need in the constructor, and reuse it in every call (Kryo, Protostuff, etc), and some create a new buffer each time object is serialized (all that use outputStream function, Wobly, maybe some others).

All serializers should probably be either using one initialized buffer, or creating new buffer each time.
This change changes outputStream function not to create buffer each time, and does the same thing for Wobly.(though it probably doesn't cover all serializers that currently create a buffer each time).
