### PR TITLE
Add the full serialization mode to benchmarks (reopened)

### DIFF
--- a/tpc/src/serializers/dslplatform/DSLPlatform.java
+++ b/tpc/src/serializers/dslplatform/DSLPlatform.java
@@ -29,9 +29,9 @@ import data.media.MediaTransformer;
 public class DSLPlatform {
     public static void register(final TestGroups groups) {
         groups.media.add(new DSLPlatformMediaTransformer(), new DSLPlatformSerializer(false), new SerFeatures(
-                SerFormat.JSON, SerGraph.FLAT_TREE, SerClass.CLASSES_KNOWN, "")); // Full serialization
+                SerFormat.JSON, SerGraph.FLAT_TREE, SerClass.CLASSES_KNOWN, "Serializes all properties.")); // Full serialization
         groups.media.add(new DSLPlatformMediaTransformer(), new DSLPlatformSerializer(true), new SerFeatures(
-                SerFormat.JSON, SerGraph.FLAT_TREE, SerClass.CLASSES_KNOWN, "")); // Minimal serialization
+                SerFormat.JSON, SerGraph.FLAT_TREE, SerClass.CLASSES_KNOWN, "Omits default values from the JSON output.")); // Minimal serialization
     }
 
     static class DSLPlatformSerializer extends Serializer<MediaContent> {
@@ -40,7 +40,7 @@ public class DSLPlatform {
 
         @Override
         public String getName() {
-            return "json/dsl-platform" + (this.minimal ? "/minimal" : "/full");
+            return "json/dsl-platform" + (this.minimal ? "/omit-defaults" : "");
         }
         
         public DSLPlatformSerializer(){

--- a/tpc/src/serializers/dslplatform/DSLPlatform.java
+++ b/tpc/src/serializers/dslplatform/DSLPlatform.java
@@ -28,16 +28,27 @@ import data.media.MediaTransformer;
  */
 public class DSLPlatform {
     public static void register(final TestGroups groups) {
-        groups.media.add(new DSLPlatformMediaTransformer(), new DSLPlatformSerializer(), new SerFeatures(
-                SerFormat.JSON, SerGraph.FLAT_TREE, SerClass.CLASSES_KNOWN, ""));
+        groups.media.add(new DSLPlatformMediaTransformer(), new DSLPlatformSerializer(false), new SerFeatures(
+                SerFormat.JSON, SerGraph.FLAT_TREE, SerClass.CLASSES_KNOWN, "")); // Full serialization
+        groups.media.add(new DSLPlatformMediaTransformer(), new DSLPlatformSerializer(true), new SerFeatures(
+                SerFormat.JSON, SerGraph.FLAT_TREE, SerClass.CLASSES_KNOWN, "")); // Minimal serialization
     }
 
     static class DSLPlatformSerializer extends Serializer<MediaContent> {
         private static JsonWriter writer = new JsonWriter();
+        private final boolean minimal;
 
         @Override
         public String getName() {
-            return "json/dsl-platform";
+            return "json/dsl-platform" + (this.minimal ? "/minimal" : "/full");
+        }
+        
+        public DSLPlatformSerializer(){
+            this(true); // minimal serialization
+        }	
+
+        public DSLPlatformSerializer(boolean minimal){
+            this.minimal = minimal;
         }
 
         @Override
@@ -48,7 +59,7 @@ public class DSLPlatform {
         @Override
         public byte[] serialize(final MediaContent content) throws Exception {
             writer.reset();
-            content.serialize(writer, true);
+            content.serialize(writer, this.minimal);
             return writer.toByteArray();
         }
     }


### PR DESCRIPTION
(Continuing on https://github.com/eishay/jvm-serializers/pull/49)

Added the full/minimal serialization modes distinction for json/dsl-platform. The minimal serialization mode omits default values from the serialization output, while the full mode writes out all properties.

The new modes are called 'json/dsl-platform' and 'json/dsl-platform/omit-defaults" in the benchmark results (newly generated graphs: http://hperadin.github.io/jvm-serializers-report/report.html).
