### PR TITLE
DSL Platform minified json codec name change.

### DIFF
--- a/tpc/src/serializers/dslplatform/DSLPlatform.java
+++ b/tpc/src/serializers/dslplatform/DSLPlatform.java
@@ -63,7 +63,7 @@ public class DSLPlatform {
 
         @Override
         public String getName() {
-            return "json/dsl-platform/minified";
+            return "minified-json/dsl-platform";
         }
 
         @Override


### PR DESCRIPTION
Changed from json/dsl-platform/minified => minified-json/dsl-platform to improve differentiation from standard JSON codecs.
This tests uses minified property aliases and omits default values from resulting JSON.