### PR TITLE
fix measurement unit to nonasecond for average/deviation

### DIFF
--- a/tpc/src/serializers/TestCase.java
+++ b/tpc/src/serializers/TestCase.java
@@ -2,5 +2,8 @@ package serializers;
 
 public abstract class TestCase
 {
+    /**
+     * @return avg time cost every iteration, measure in nanosecond unit
+     */
     public abstract <J> double run(Transformer<J,Object> transformer, Serializer<Object> serializer, J value, int iterations) throws Exception;
 }

--- a/tpc/src/serializers/TestCaseRunner.java
+++ b/tpc/src/serializers/TestCaseRunner.java
@@ -58,7 +58,7 @@ public final class TestCaseRunner<J>
         System.err.println("1/2:"+measurementVals[count/2]);
         System.err.println("3/4:"+measurementVals[count/4*3]);
         System.err.println("max:"+measurementVals[count-1]);
-        System.err.println("average:"+ avg +"ms deviation:"+(avg-measurementVals[count/2])+"ms");
+        System.err.println("average:"+ avg +"ns deviation:"+(avg-measurementVals[count/2])+"ns, total iteration:" + count * iterations);
         System.err.println("-----------------------------------------------------------------------------");
         return avg;
     }


### PR DESCRIPTION
the result of every iteration `serializers.TestCase#run` is measured by System.nanoTime(), so the average and deviation should not be `ms` unit, it must be `ns` unit. 