### PR TITLE
Disable fury ByteArrayStream copy opimization

### DIFF
--- a/tpc/src/serializers/fury/Fury.java
+++ b/tpc/src/serializers/fury/Fury.java
@@ -7,6 +7,7 @@ import data.media.Media;
 import data.media.MediaContent;
 import data.media.MediaTransformer;
 import io.fury.config.FuryBuilder;
+import io.fury.util.LoggerFactory;
 import serializers.JavaBuiltIn;
 import serializers.SerClass;
 import serializers.SerFeatures;
@@ -27,7 +28,6 @@ public class Fury {
 	public static void register (TestGroups groups) {
 		register(groups.media, JavaBuiltIn.mediaTransformer, MediaTypeHandler);
 	}
-
 
 	public static final MediaTransformer<MediaContent> mediaTransformer = new MediaTransformer<MediaContent>() {
 
@@ -97,6 +97,7 @@ public class Fury {
 			TypeHandler<T> handler, String name, boolean register, boolean references, boolean compression) {
 			this.type = handler.type;
 			this.name = name;
+			LoggerFactory.disableLogging();
 			FuryBuilder builder = io.fury.Fury.builder()
 				.withRefTracking(references)
 				.requireClassRegistration(register);


### PR DESCRIPTION
As [#89 ](https://github.com/eishay/jvm-serializers/pull/89#issuecomment-1751699893) said, fury `io.fury.Fury#serializeJavaObject(java.io.OutputStream, java.lang.Object)` may save a copy inside, which may affect the benchmark result. 

This won't make very much difference since serialization is much more time consuming than the copy of `~250` bytes, but to make the benchmark result more solid, this PR workaround it by copying the data manually .



